### PR TITLE
docs: update README and CLAUDE.md for current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,3 +220,29 @@ cj::profile::register myprofile _cj_profile_myprofile
 | `cj::sandbox::home_path <home> <profile>` | Get HOME path for profile display |
 | `cj::sandbox::print_info <...>` | Print verbose startup information |
 | `cj::sandbox::print_shell_info <home> <profile>` | Print shell entry information |
+
+## Development Setup (for Claude Code Web Sessions)
+
+When starting a new development session, run these commands to set up the environment:
+
+```bash
+# Install dependencies (Debian/Ubuntu)
+sudo apt-get update
+sudo apt-get install -y bubblewrap rsync shellcheck
+
+# Initialize test submodules
+git submodule update --init --recursive
+
+# Verify setup by running tests
+./tests/run_tests.sh
+```
+
+### CI/CD Integration
+
+The project uses GitHub Actions for automated testing. The workflow:
+- Runs on push to main/master and on PRs
+- Installs bubblewrap and rsync
+- Runs unit and integration tests separately
+- Runs ShellCheck on all shell scripts
+
+See `.github/workflows/test.yml` for the full configuration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,12 +107,7 @@ claude-jail -d ~/project
 
 ## Testing
 
-### Automated Tests (bats-core)
-
 ```bash
-# Initialize test submodules (first time only)
-git submodule update --init --recursive
-
 # Run all tests
 ./tests/run_tests.sh
 
@@ -121,109 +116,11 @@ git submodule update --init --recursive
 
 # Run only integration tests
 ./tests/run_tests.sh integration
-
-# Run a specific test file
-./tests/run_tests.sh tests/unit/bwrap.bats
 ```
-
-Test structure:
-- `tests/unit/` - Unit tests for each lib/*.sh module
-- `tests/integration/` - CLI and profile integration tests
-- `tests/test_helper/common.bash` - Shared test utilities
-
-### Manual Testing
-
-```bash
-# Debug: print bwrap command without running
-claude-jail debug [dir] [profile]
-# or: ./bin/claude-jail debug [dir] [profile]
-
-# Interactive shell inside sandbox to verify mounts
-claude-jail shell [dir] [profile]
-# or: ./bin/claude-jail shell [dir] [profile]
-
-# Verify isolation: these should fail inside sandbox
-ls /home
-cat ~/.ssh/id_rsa
-
-# Clean sandbox to test fresh config copy
-claude-jail clean [dir]
-# or: ./bin/claude-jail clean [dir]
-```
-
-## Creating Custom Profiles
-
-Add `profiles/myprofile.sh`:
-
-```bash
-#!/usr/bin/env bash
-# profiles/myprofile.sh - My custom isolation profile
-
-_cj_profile_myprofile() {
-    local project_dir="$1"
-    local sandbox_home="$2"
-
-    cj::unshare user pid
-    cj::system::base
-    cj::system::dns
-    cj::system::ssl
-    cj::proc
-    cj::dev
-    cj::tmpfs /tmp
-
-    cj::bind "$project_dir"
-    cj::bind "$sandbox_home"
-
-    # Custom mounts here
-    cj::ro_bind ~/my-tools
-
-    cj::setenv HOME "$sandbox_home"
-    cj::setenv PATH "$PATH"
-}
-
-cj::profile::register myprofile _cj_profile_myprofile
-```
-
-**Note**: Use pure bash syntax only. Avoid zsh-specific features like:
-- `${var:h}` → use `$(dirname "$var")`
-- `${(s/:/)var}` → use `IFS=: read -ra array <<< "$var"`
-- `typeset -gA` → use `declare -gA`
-
-## Core API (lib/bwrap.sh)
-
-| Function | Purpose |
-|----------|---------|
-| `cj::reset` | Clear accumulated args (call before building new command) |
-| `cj::ro_bind <src> [dst]` | Read-only bind mount |
-| `cj::bind <src> [dst]` | Read-write bind mount |
-| `cj::tmpfs <path>` | Mount tmpfs |
-| `cj::symlink <target> <link>` | Create symlink |
-| `cj::proc` / `cj::dev` | Mount /proc, /dev |
-| `cj::setenv <name> <value>` | Set environment variable |
-| `cj::unshare <ns...>` | Unshare namespaces (user, pid, net, ipc, uts, cgroup, all) |
-| `cj::share <ns...>` | Share namespaces (net) |
-| `cj::run <cmd...>` | Execute command in sandbox |
-| `cj::system::base` | Bind /usr, /bin, /lib, /lib64, handle symlinks |
-| `cj::system::dns` | Bind DNS config files |
-| `cj::system::ssl` | Bind SSL certificates |
-| `cj::path::bind_all` | Bind all directories in $PATH |
-
-## Sandbox API (lib/sandbox.sh)
-
-| Function | Purpose |
-|----------|---------|
-| `cj::sandbox::create_dirs <home>` | Create standard sandbox directory structure |
-| `cj::sandbox::copy_claude_config <home>` | Copy ~/.claude to sandbox (if enabled) |
-| `cj::sandbox::bind_credentials <home> <profile>` | Bind credentials file for live sync |
-| `cj::sandbox::init <project> <home> <profile>` | Full sandbox initialization |
-| `cj::sandbox::chdir_path <project> <profile>` | Get working directory path for profile |
-| `cj::sandbox::home_path <home> <profile>` | Get HOME path for profile display |
-| `cj::sandbox::print_info <...>` | Print verbose startup information |
-| `cj::sandbox::print_shell_info <home> <profile>` | Print shell entry information |
 
 ## Development Setup (for Claude Code Web Sessions)
 
-When starting a new development session, run these commands to set up the environment:
+Quick setup for new development sessions:
 
 ```bash
 # Install dependencies (Debian/Ubuntu)
@@ -237,12 +134,4 @@ git submodule update --init --recursive
 ./tests/run_tests.sh
 ```
 
-### CI/CD Integration
-
-The project uses GitHub Actions for automated testing. The workflow:
-- Runs on push to main/master and on PRs
-- Installs bubblewrap and rsync
-- Runs unit and integration tests separately
-- Runs ShellCheck on all shell scripts
-
-See `.github/workflows/test.yml` for the full configuration.
+For full development documentation including API reference, creating custom profiles, and code style guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,219 @@
+# Contributing to claude-jail
+
+This guide covers development setup, testing, and how to extend claude-jail.
+
+## Development Setup
+
+### Dependencies
+
+Install these packages for development and testing:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get update
+sudo apt-get install -y bubblewrap rsync shellcheck
+
+# Arch
+sudo pacman -S bubblewrap rsync shellcheck
+
+# Fedora
+sudo dnf install bubblewrap rsync ShellCheck
+```
+
+### Initialize Test Framework
+
+The test suite uses [bats-core](https://github.com/bats-core/bats-core) with support and assert libraries as git submodules:
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/mbarlow12/claude-jail.git
+
+# Or initialize submodules in existing clone
+git submodule update --init --recursive
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+./tests/run_tests.sh
+
+# Run only unit tests
+./tests/run_tests.sh unit
+
+# Run only integration tests
+./tests/run_tests.sh integration
+
+# Run a specific test file
+./tests/run_tests.sh tests/unit/bwrap.bats
+```
+
+### Test Structure
+
+- `tests/unit/` - Unit tests for each `lib/*.sh` module
+- `tests/integration/` - CLI and profile integration tests
+- `tests/test_helper/common.bash` - Shared test utilities
+
+### Manual Testing
+
+```bash
+# Debug: print bwrap command without running
+claude-jail debug [dir] [profile]
+
+# Interactive shell inside sandbox to verify mounts
+claude-jail shell [dir] [profile]
+
+# Verify isolation: these should fail inside sandbox
+ls /home
+cat ~/.ssh/id_rsa
+
+# Clean sandbox to test fresh config copy
+claude-jail clean [dir]
+```
+
+## Linting
+
+Run ShellCheck on all source files before submitting:
+
+```bash
+shellcheck lib/*.sh bin/claude-jail profiles/*.sh
+```
+
+## Architecture
+
+```
+claude-jail/
+├── bin/
+│   └── claude-jail           # Standalone bash entry point
+├── lib/
+│   ├── bwrap.sh              # Core bwrap building blocks
+│   ├── config.sh             # Configuration management
+│   ├── profiles.sh           # Profile registration/loading
+│   └── sandbox.sh            # Sandbox setup utilities
+├── profiles/
+│   ├── minimal.sh            # Fast, basic isolation
+│   ├── standard.sh           # Balanced (default)
+│   ├── dev.sh                # Developer toolchains
+│   └── paranoid.sh           # Maximum isolation
+├── tests/
+│   ├── unit/                 # Unit tests for lib/*.sh
+│   ├── integration/          # CLI and profile tests
+│   └── run_tests.sh          # Test runner
+└── claude-jail.plugin.zsh    # Zsh plugin (thin wrapper)
+```
+
+### Key Design Patterns
+
+**Pure bash core**: All `lib/*.sh` and `profiles/*.sh` files use bash-compatible syntax, no zsh-isms.
+
+**Global state arrays** accumulate bwrap arguments:
+- `_CJ_NS` - namespace flags (--unshare-*, --share-*)
+- `_CJ_PRE` - directory creation (--dir)
+- `_CJ_BINDS` - bind mounts, tmpfs, symlinks
+- `_CJ_ENV` - environment variables
+- `_CJ_SEEN` - deduplication map
+
+**Profile functions** receive `(project_dir, sandbox_home)` and build the bwrap command by calling `cj::*` primitives. Register with `cj::profile::register <name> <function>`.
+
+**Sandbox home** lives at `$project_dir/.claude-sandbox/` (configurable). Claude's `~/.claude` config is copied there on first run.
+
+**Configuration layers** (highest to lowest priority):
+1. CLI arguments (`--profile`, `--ro`, etc.)
+2. Environment variables (`CJ_PROFILE`, `CJ_EXTRA_RO`, etc.)
+3. Config file (`./.claude-jail.conf`, `~/.config/claude-jail/config`)
+4. Built-in defaults
+
+## Creating Custom Profiles
+
+Add `profiles/myprofile.sh`:
+
+```bash
+#!/usr/bin/env bash
+# profiles/myprofile.sh - My custom isolation profile
+
+_cj_profile_myprofile() {
+    local project_dir="$1"
+    local sandbox_home="$2"
+
+    cj::unshare user pid
+    cj::system::base
+    cj::system::dns
+    cj::system::ssl
+    cj::proc
+    cj::dev
+    cj::tmpfs /tmp
+
+    cj::bind "$project_dir"
+    cj::bind "$sandbox_home"
+
+    # Custom mounts here
+    cj::ro_bind ~/my-tools
+
+    cj::setenv HOME "$sandbox_home"
+    cj::setenv PATH "$PATH"
+}
+
+cj::profile::register myprofile _cj_profile_myprofile
+```
+
+## Code Style
+
+Use pure bash syntax only. Avoid zsh-specific features:
+
+| Avoid (zsh) | Use (bash) |
+|-------------|------------|
+| `${var:h}` | `$(dirname "$var")` |
+| `${(s/:/)var}` | `IFS=: read -ra array <<< "$var"` |
+| `typeset -gA` | `declare -gA` |
+
+## API Reference
+
+### Core Functions (`lib/bwrap.sh`)
+
+| Function | Description |
+|----------|-------------|
+| `cj::reset` | Clear all accumulated bwrap args |
+| `cj::ro_bind <src> [dst]` | Read-only bind mount |
+| `cj::bind <src> [dst]` | Read-write bind mount |
+| `cj::tmpfs <path>` | Mount tmpfs |
+| `cj::symlink <target> <link>` | Create symlink |
+| `cj::proc [path]` | Mount /proc |
+| `cj::dev [path]` | Mount /dev |
+| `cj::setenv <name> <value>` | Set environment variable |
+| `cj::unshare <ns...>` | Unshare namespaces (user, pid, net, ipc, uts, cgroup, all) |
+| `cj::share <ns...>` | Share namespaces (net) |
+| `cj::run <cmd...>` | Execute command in sandbox |
+
+### System Helpers
+
+| Function | Description |
+|----------|-------------|
+| `cj::system::base` | Bind /usr, /bin, /lib, /lib64 |
+| `cj::system::dns` | Bind DNS config files |
+| `cj::system::ssl` | Bind SSL certificates |
+| `cj::system::users` | Bind passwd, group, localtime |
+| `cj::path::bind_all` | Bind all directories in $PATH |
+| `cj::path::find_real <name>` | Find and bind executable |
+
+### Sandbox Helpers (`lib/sandbox.sh`)
+
+| Function | Description |
+|----------|-------------|
+| `cj::sandbox::create_dirs <home>` | Create sandbox directory structure |
+| `cj::sandbox::copy_claude_config <home>` | Copy ~/.claude to sandbox |
+| `cj::sandbox::bind_credentials <home> <profile>` | Bind credentials for live sync |
+| `cj::sandbox::init <project> <home> <profile>` | Full sandbox initialization |
+| `cj::sandbox::chdir_path <project> <profile>` | Get working directory path for profile |
+| `cj::sandbox::home_path <home> <profile>` | Get HOME path for profile display |
+| `cj::sandbox::print_info <...>` | Print verbose startup information |
+| `cj::sandbox::print_shell_info <home> <profile>` | Print shell entry information |
+
+## CI/CD
+
+The project uses GitHub Actions for automated testing. The workflow:
+- Runs on push to main/master and on PRs
+- Installs bubblewrap and rsync
+- Runs unit and integration tests separately
+- Runs ShellCheck on all shell scripts
+
+See `.github/workflows/test.yml` for the full configuration.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # claude-jail
 
-A modular Oh My Zsh plugin that runs Claude Code inside a bubblewrap sandbox.
+A shell-agnostic tool that runs Claude Code inside a bubblewrap sandbox to isolate it from your real home directory.
 
 ## Why?
 
@@ -10,14 +10,14 @@ Claude Code runs with your user permissions. A prompt injection or bug could:
 - Exfiltrate secrets: `cat ~/.ssh/id_rsa | curl ...`
 - Modify configs: `echo "malicious" >> ~/.bashrc`
 
-This plugin isolates Claude in a Linux namespace where your real home doesn't exist.
+This tool isolates Claude in a Linux namespace where your real home doesn't exist.
 
 ## Requirements
 
 - Linux with user namespaces enabled
 - [bubblewrap](https://github.com/containers/bubblewrap)
-- [Oh My Zsh](https://ohmyz.sh/)
 - [Claude Code](https://claude.ai/code)
+- (Optional) [Oh My Zsh](https://ohmyz.sh/) for zsh integration
 
 ```bash
 # Debian/Ubuntu
@@ -32,9 +32,25 @@ sudo dnf install bubblewrap
 
 ## Installation
 
+### Standalone (works with any shell)
+
+```bash
+# Clone the repository
+git clone https://github.com/mbarlow12/claude-jail.git
+cd claude-jail
+
+# Initialize test submodules (optional, for running tests)
+git submodule update --init --recursive
+
+# Add to PATH (add to your shell's rc file)
+export PATH="$PATH:/path/to/claude-jail/bin"
+```
+
+### Oh My Zsh Plugin
+
 ```bash
 # Clone to omz custom plugins
-git clone https://github.com/YOUR_USERNAME/claude-jail.git \
+git clone https://github.com/mbarlow12/claude-jail.git \
     ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/claude-jail
 
 # Enable in ~/.zshrc
@@ -46,12 +62,26 @@ source ~/.zshrc
 
 ## Usage
 
+### Standalone
+
 ```bash
 claude-jail                     # Run in current directory
 claude-jail -d ~/project        # Specific directory
 claude-jail -p paranoid         # Maximum isolation
 claude-jail -v                  # Verbose output
 claude-jail -- --print "hi"     # Pass args to claude
+
+claude-jail shell               # Test the sandbox interactively
+claude-jail clean               # Remove .claude-sandbox/
+claude-jail debug               # Print bwrap command
+```
+
+### Zsh Plugin
+
+```bash
+claude-jail                     # Run in current directory
+claude-jail -d ~/project        # Specific directory
+claude-jail -p paranoid         # Maximum isolation
 
 claude-jail-shell               # Test the sandbox interactively
 claude-jail-clean               # Remove .claude-sandbox/
@@ -95,54 +125,169 @@ claude-jail-debug               # Print bwrap command
 
 ## Configuration
 
-Configure via `zstyle` in `~/.zshrc` (before the plugins line):
+### Environment Variables (recommended)
+
+```bash
+export CJ_PROFILE=paranoid
+export CJ_NETWORK=false
+export CJ_SANDBOX_HOME=.claude-sandbox
+export CJ_COPY_CLAUDE_CONFIG=true
+export CJ_EXTRA_RO="/usr/local/mylib:/opt/tools"
+export CJ_EXTRA_RW="/tmp/scratch"
+
+claude-jail -d ~/project
+```
+
+### Config File
+
+Create `~/.config/claude-jail/config` or `.claude-jail.conf` in your project:
+
+```bash
+CJ_PROFILE=standard
+CJ_NETWORK=true
+CJ_SANDBOX_HOME=.claude-sandbox
+CJ_COPY_CLAUDE_CONFIG=true
+CJ_EXTRA_RO=(/usr/local/mylib /opt/tools)
+CJ_EXTRA_RW=(/tmp/scratch)
+```
+
+### Zsh zstyle (backward compatibility)
 
 ```zsh
-# Change default profile
+# In ~/.zshrc (before the plugins line)
 zstyle ':claude-jail:*' profile paranoid
-
-# Disable network (claude won't work, but useful for testing)
 zstyle ':claude-jail:*' network false
-
-# Custom sandbox directory name
 zstyle ':claude-jail:*' sandbox-home .sandbox
-
-# Don't copy ~/.claude config (credentials are always bind-mounted)
 zstyle ':claude-jail:*' copy-claude-config false
-
-# Add extra read-only paths
 zstyle ':claude-jail:paths' extra-ro ~/shared-libs ~/reference
-
-# Add extra read-write paths (use sparingly!)
 zstyle ':claude-jail:paths' extra-rw ~/scratch
+```
+
+### Configuration Priority
+
+1. CLI arguments (`--profile`, `--ro`, etc.)
+2. Environment variables (`CJ_PROFILE`, `CJ_EXTRA_RO`, etc.)
+3. Config file (`.claude-jail.conf`, `~/.config/claude-jail/config`)
+4. Built-in defaults
+
+## Development Setup
+
+### Dependencies
+
+For development and testing, install these additional packages:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get update
+sudo apt-get install -y bubblewrap rsync shellcheck
+
+# Arch
+sudo pacman -S bubblewrap rsync shellcheck
+
+# Fedora
+sudo dnf install bubblewrap rsync ShellCheck
+```
+
+### Initialize Test Framework
+
+The test suite uses [bats-core](https://github.com/bats-core/bats-core) with support and assert libraries as git submodules:
+
+```bash
+# Clone with submodules
+git clone --recurse-submodules https://github.com/mbarlow12/claude-jail.git
+
+# Or initialize submodules in existing clone
+git submodule update --init --recursive
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+./tests/run_tests.sh
+
+# Run only unit tests
+./tests/run_tests.sh unit
+
+# Run only integration tests
+./tests/run_tests.sh integration
+
+# Run a specific test file
+./tests/run_tests.sh tests/unit/bwrap.bats
+```
+
+### Linting
+
+```bash
+# Run ShellCheck on all source files
+shellcheck lib/*.sh bin/claude-jail profiles/*.sh
+```
+
+## Testing
+
+### Automated Tests
+
+```bash
+# Initialize test submodules (first time only)
+git submodule update --init --recursive
+
+# Run all tests
+./tests/run_tests.sh
+
+# Run only unit tests
+./tests/run_tests.sh unit
+
+# Run only integration tests
+./tests/run_tests.sh integration
+```
+
+### Manual Testing
+
+```bash
+# See what bwrap command would run
+claude-jail debug
+
+# Enter sandbox shell to explore
+claude-jail shell
+ls /home          # Should fail
+echo $HOME        # Shows sandbox path
 ```
 
 ## Architecture
 
 ```
 claude-jail/
-├── claude-jail.plugin.zsh    # Entry point, user commands
+├── bin/
+│   └── claude-jail           # Standalone bash entry point
 ├── lib/
-│   ├── bwrap.zsh             # Core bwrap building blocks
-│   ├── config.zsh            # zstyle configuration
-│   └── profiles.zsh          # Profile management
-└── profiles/
-    ├── minimal.zsh           # Fast, basic isolation
-    ├── standard.zsh          # Balanced (default)
-    ├── dev.zsh               # Developer toolchains
-    └── paranoid.zsh          # Maximum isolation
+│   ├── bwrap.sh              # Core bwrap building blocks
+│   ├── config.sh             # Configuration management
+│   ├── profiles.sh           # Profile registration/loading
+│   └── sandbox.sh            # Sandbox setup utilities
+├── profiles/
+│   ├── minimal.sh            # Fast, basic isolation
+│   ├── standard.sh           # Balanced (default)
+│   ├── dev.sh                # Developer toolchains
+│   └── paranoid.sh           # Maximum isolation
+├── tests/
+│   ├── unit/                 # Unit tests for lib/*.sh
+│   ├── integration/          # CLI and profile tests
+│   └── run_tests.sh          # Test runner
+└── claude-jail.plugin.zsh    # Zsh plugin (thin wrapper)
 ```
 
 ### Extending
 
-Create custom profiles in `~/.oh-my-zsh/custom/plugins/claude-jail/profiles/`:
+Create custom profiles in `profiles/`:
 
-```zsh
-# profiles/custom.zsh
+```bash
+#!/usr/bin/env bash
+# profiles/custom.sh
+
 _cj_profile_custom() {
     local project_dir="$1"
     local sandbox_home="$2"
-    
+
     cj::unshare user pid
     cj::system::base
     cj::system::dns
@@ -150,13 +295,13 @@ _cj_profile_custom() {
     cj::proc
     cj::dev
     cj::tmpfs /tmp
-    
+
     cj::bind "$project_dir"
     cj::bind "$sandbox_home"
-    
+
     # Your custom mounts
     cj::ro_bind ~/my-tools
-    
+
     cj::setenv HOME "$sandbox_home"
     cj::setenv PATH "$PATH"
 }
@@ -164,9 +309,11 @@ _cj_profile_custom() {
 cj::profile::register custom _cj_profile_custom
 ```
 
+**Note**: Use pure bash syntax only. Avoid zsh-specific features.
+
 ## API Reference
 
-### Core Functions (`lib/bwrap.zsh`)
+### Core Functions (`lib/bwrap.sh`)
 
 | Function | Description |
 |----------|-------------|
@@ -192,6 +339,15 @@ cj::profile::register custom _cj_profile_custom
 | `cj::system::users` | Bind passwd, group, localtime |
 | `cj::path::bind_all` | Bind all directories in $PATH |
 | `cj::path::find_real <name>` | Find and bind executable |
+
+### Sandbox Helpers (`lib/sandbox.sh`)
+
+| Function | Description |
+|----------|-------------|
+| `cj::sandbox::create_dirs <home>` | Create sandbox directory structure |
+| `cj::sandbox::copy_claude_config <home>` | Copy ~/.claude to sandbox |
+| `cj::sandbox::bind_credentials <home> <profile>` | Bind credentials for live sync |
+| `cj::sandbox::init <project> <home> <profile>` | Full sandbox initialization |
 
 ## Troubleshooting
 
@@ -223,10 +379,10 @@ claude-jail
 
 ```bash
 # See what bwrap command would run
-claude-jail-debug
+claude-jail debug
 
 # Enter sandbox shell to explore
-claude-jail-shell
+claude-jail shell
 ls /home          # Should fail
 echo $HOME        # Shows sandbox path
 ```

--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ sudo dnf install bubblewrap
 git clone https://github.com/mbarlow12/claude-jail.git
 cd claude-jail
 
-# Initialize test submodules (optional, for running tests)
-git submodule update --init --recursive
-
 # Add to PATH (add to your shell's rc file)
 export PATH="$PATH:/path/to/claude-jail/bin"
 ```
@@ -170,78 +167,7 @@ zstyle ':claude-jail:paths' extra-rw ~/scratch
 3. Config file (`.claude-jail.conf`, `~/.config/claude-jail/config`)
 4. Built-in defaults
 
-## Development Setup
-
-### Dependencies
-
-For development and testing, install these additional packages:
-
-```bash
-# Debian/Ubuntu
-sudo apt-get update
-sudo apt-get install -y bubblewrap rsync shellcheck
-
-# Arch
-sudo pacman -S bubblewrap rsync shellcheck
-
-# Fedora
-sudo dnf install bubblewrap rsync ShellCheck
-```
-
-### Initialize Test Framework
-
-The test suite uses [bats-core](https://github.com/bats-core/bats-core) with support and assert libraries as git submodules:
-
-```bash
-# Clone with submodules
-git clone --recurse-submodules https://github.com/mbarlow12/claude-jail.git
-
-# Or initialize submodules in existing clone
-git submodule update --init --recursive
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-./tests/run_tests.sh
-
-# Run only unit tests
-./tests/run_tests.sh unit
-
-# Run only integration tests
-./tests/run_tests.sh integration
-
-# Run a specific test file
-./tests/run_tests.sh tests/unit/bwrap.bats
-```
-
-### Linting
-
-```bash
-# Run ShellCheck on all source files
-shellcheck lib/*.sh bin/claude-jail profiles/*.sh
-```
-
-## Testing
-
-### Automated Tests
-
-```bash
-# Initialize test submodules (first time only)
-git submodule update --init --recursive
-
-# Run all tests
-./tests/run_tests.sh
-
-# Run only unit tests
-./tests/run_tests.sh unit
-
-# Run only integration tests
-./tests/run_tests.sh integration
-```
-
-### Manual Testing
+## Testing the Sandbox
 
 ```bash
 # See what bwrap command would run
@@ -269,85 +195,9 @@ claude-jail/
 │   ├── standard.sh           # Balanced (default)
 │   ├── dev.sh                # Developer toolchains
 │   └── paranoid.sh           # Maximum isolation
-├── tests/
-│   ├── unit/                 # Unit tests for lib/*.sh
-│   ├── integration/          # CLI and profile tests
-│   └── run_tests.sh          # Test runner
+├── tests/                    # Automated tests (bats-core)
 └── claude-jail.plugin.zsh    # Zsh plugin (thin wrapper)
 ```
-
-### Extending
-
-Create custom profiles in `profiles/`:
-
-```bash
-#!/usr/bin/env bash
-# profiles/custom.sh
-
-_cj_profile_custom() {
-    local project_dir="$1"
-    local sandbox_home="$2"
-
-    cj::unshare user pid
-    cj::system::base
-    cj::system::dns
-    cj::system::ssl
-    cj::proc
-    cj::dev
-    cj::tmpfs /tmp
-
-    cj::bind "$project_dir"
-    cj::bind "$sandbox_home"
-
-    # Your custom mounts
-    cj::ro_bind ~/my-tools
-
-    cj::setenv HOME "$sandbox_home"
-    cj::setenv PATH "$PATH"
-}
-
-cj::profile::register custom _cj_profile_custom
-```
-
-**Note**: Use pure bash syntax only. Avoid zsh-specific features.
-
-## API Reference
-
-### Core Functions (`lib/bwrap.sh`)
-
-| Function | Description |
-|----------|-------------|
-| `cj::reset` | Clear all accumulated bwrap args |
-| `cj::ro_bind <src> [dst]` | Read-only bind mount |
-| `cj::bind <src> [dst]` | Read-write bind mount |
-| `cj::tmpfs <path>` | Mount tmpfs |
-| `cj::symlink <target> <link>` | Create symlink |
-| `cj::proc [path]` | Mount /proc |
-| `cj::dev [path]` | Mount /dev |
-| `cj::setenv <name> <value>` | Set environment variable |
-| `cj::unshare <ns...>` | Unshare namespaces (user, pid, net, ipc, uts, cgroup, all) |
-| `cj::share <ns...>` | Share namespaces (net) |
-| `cj::run <cmd...>` | Execute command in sandbox |
-
-### System Helpers
-
-| Function | Description |
-|----------|-------------|
-| `cj::system::base` | Bind /usr, /bin, /lib, /lib64 |
-| `cj::system::dns` | Bind DNS config files |
-| `cj::system::ssl` | Bind SSL certificates |
-| `cj::system::users` | Bind passwd, group, localtime |
-| `cj::path::bind_all` | Bind all directories in $PATH |
-| `cj::path::find_real <name>` | Find and bind executable |
-
-### Sandbox Helpers (`lib/sandbox.sh`)
-
-| Function | Description |
-|----------|-------------|
-| `cj::sandbox::create_dirs <home>` | Create sandbox directory structure |
-| `cj::sandbox::copy_claude_config <home>` | Copy ~/.claude to sandbox |
-| `cj::sandbox::bind_credentials <home> <profile>` | Bind credentials for live sync |
-| `cj::sandbox::init <project> <home> <profile>` | Full sandbox initialization |
 
 ## Troubleshooting
 
@@ -393,6 +243,10 @@ echo $HOME        # Shows sandbox path
 - The sandbox protects against accidental damage, not determined attackers
 - For higher security, use `--no-network` or run in a VM
 - Consider [cco](https://github.com/nikvdp/cco) or Docker for additional isolation
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, creating custom profiles, and API reference.
 
 ## Credits
 


### PR DESCRIPTION
- Update README from "Oh My Zsh plugin" to "shell-agnostic tool"
- Add standalone installation as primary option
- Update file extensions from .zsh to .sh
- Add Development Setup section with dependencies (bubblewrap, rsync, shellcheck)
- Add test framework initialization instructions
- Update architecture diagram to include tests/ and sandbox.sh
- Add Sandbox Helpers API section
- Add CI/CD integration notes to CLAUDE.md