### PR TITLE
feat: add git worktree support and flexible sandbox home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Git worktree support with automatic detection and main `.git` binding (`--git-root`, `--git-ro`)
+- Configurable sandbox location via `CJ_SANDBOX_HOME` and `CJ_SANDBOX_NAME`
+
 ## [0.1.0] - 2026-01-16
 
 Initial release of claude-jail: a bubblewrap sandbox for running Claude Code in isolation. Includes standalone bash CLI, Zsh plugin, four security profiles, and automated release tooling.

--- a/bin/claude-jail
+++ b/bin/claude-jail
@@ -35,6 +35,10 @@ OPTIONS
     --no-network          Disable network access
     --ro <PATH>           Add read-only path (can repeat)
     --rw <PATH>           Add read-write path (can repeat)
+    --sandbox-home <PATH> Parent directory for sandbox (default: cwd)
+    --sandbox-name <NAME> Sandbox directory name (default: .claude-sandbox)
+    --git-root <PATH>     Manually specify main git repo root (for worktrees)
+    --git-ro              Bind main .git read-only (default: read-write)
     --list-profiles       List available profiles
     --show-config         Show current configuration
     --help-config         Show configuration help
@@ -59,6 +63,20 @@ COMMANDS
     claude-jail clean     Remove .claude-sandbox directory
     claude-jail debug     Print bwrap command without running
 
+GIT WORKTREE SUPPORT
+    claude-jail auto-detects git worktrees and binds the main .git directory.
+    This enables full git operations (commit, push, etc.) from worktrees.
+
+    # Run from parent directory with worktrees
+    cd bean-barn
+    claude-jail -d feat-ty-lsp   # Auto-binds ../main/.git
+
+    # Override if auto-detection fails
+    claude-jail -d feat-ty-lsp --git-root ./main
+
+    # Read-only for extra safety (limits some git operations)
+    claude-jail -d feat-ty-lsp --git-ro
+
 EXAMPLES
     claude-jail                       # Run in current directory
     claude-jail -d ~/project          # Run in specific directory
@@ -66,6 +84,14 @@ EXAMPLES
     claude-jail -v -- --print "hi"    # Verbose, pass args to claude
     claude-jail debug                 # See what bwrap would run
     claude-jail shell                 # Test sandbox interactively
+
+    # Shared sandbox between worktrees
+    cd ~/repos/myproject-worktrees
+    claude-jail -d main               # Sandbox at ./cwd/.claude-sandbox
+    claude-jail -d feat-branch        # Same sandbox (shared)
+
+    # Custom sandbox location
+    claude-jail --sandbox-home /tmp --sandbox-name my-sandbox
 
 SECURITY
     Inside the sandbox:
@@ -83,6 +109,10 @@ _claude_jail_main() {
     local profile=""
     local verbose=""
     local network=""
+    local sandbox_home_override=""
+    local sandbox_name_override=""
+    local git_root_override=""
+    local git_ro=""
     local -a cli_ro=()
     local -a cli_rw=()
     local -a claude_args=()
@@ -101,6 +131,10 @@ _claude_jail_main() {
             --network)      network=true; shift ;;
             --ro)           cli_ro+=("$2"); shift 2 ;;
             --rw)           cli_rw+=("$2"); shift 2 ;;
+            --sandbox-home) sandbox_home_override="$2"; shift 2 ;;
+            --sandbox-name) sandbox_name_override="$2"; shift 2 ;;
+            --git-root)     git_root_override="$2"; shift 2 ;;
+            --git-ro)       git_ro=true; shift ;;
             --)             shift; claude_args+=("$@"); break ;;
             -*)             echo "Unknown option: $1" >&2; return 1 ;;
             *)              claude_args+=("$1"); shift ;;
@@ -129,13 +163,29 @@ _claude_jail_main() {
         return 1
     fi
 
-    local sandbox_home_name
-    sandbox_home_name="$(cj::config::get sandbox_home .claude-sandbox)"
-    local sandbox_home="$project_dir/$sandbox_home_name"
+    # Resolve sandbox home using new flexible resolution
+    local sandbox_home
+    sandbox_home="$(cj::sandbox::resolve_home "${sandbox_home_override:-}" "${sandbox_name_override:-}")"
+
+    # Validate sandbox location
+    local config_source=""
+    if cj::config::is_user_level_config && [[ -n "$(cj::config::get sandbox_home)" ]]; then
+        config_source="user"
+    fi
+    if ! cj::sandbox::validate_home_location "$sandbox_home" "$config_source"; then
+        return 1
+    fi
 
     cj::sandbox::init "$project_dir" "$sandbox_home" "$profile"
     cj::worktree::detect_config "$project_dir" "${verbose:-false}"
     cj::sandbox::bind_credentials "$sandbox_home" "$profile" || true
+
+    # Detect and bind git worktree's main .git directory
+    local git_worktree_ro="${git_ro:-$(cj::config::get_bool git_worktree_ro false && echo true || echo false)}"
+    if [[ -n "$git_root_override" ]]; then
+        git_root_override="$(realpath "$git_root_override" 2>/dev/null || echo "$git_root_override")"
+    fi
+    cj::git::detect_worktree "$project_dir" "$git_worktree_ro" "${verbose:-false}" "$git_root_override" || true
 
     # Pass through environment variables (git, proxy, API key)
     cj::env::passthrough
@@ -189,11 +239,12 @@ _claude_jail_shell() {
 
     project_dir="$(realpath "$project_dir" 2>/dev/null || echo "$project_dir")"
     local sandbox_home
-    sandbox_home="$project_dir/$(cj::config::get sandbox_home .claude-sandbox)"
+    sandbox_home="$(cj::sandbox::resolve_home)"
 
     cj::sandbox::init "$project_dir" "$sandbox_home" "$profile"
     cj::sandbox::bind_credentials "$sandbox_home" "$profile" || true
     cj::env::passthrough
+    cj::git::detect_worktree "$project_dir" "$(cj::config::get_bool git_worktree_ro false && echo true || echo false)" false "" || true
 
     local chdir_path
     chdir_path="$(cj::sandbox::chdir_path "$project_dir" "$profile")"
@@ -207,7 +258,7 @@ _claude_jail_shell() {
 _claude_jail_clean() {
     local project_dir="${1:-$(pwd)}"
     local sandbox_home
-    sandbox_home="$project_dir/$(cj::config::get sandbox_home .claude-sandbox)"
+    sandbox_home="$(cj::sandbox::resolve_home)"
 
     if [[ -d "$sandbox_home" ]]; then
         echo "Removing $sandbox_home ..."
@@ -224,7 +275,7 @@ _claude_jail_debug() {
 
     project_dir="$(realpath "$project_dir" 2>/dev/null || echo "$project_dir")"
     local sandbox_home
-    sandbox_home="$project_dir/$(cj::config::get sandbox_home .claude-sandbox)"
+    sandbox_home="$(cj::sandbox::resolve_home)"
 
     # Create sandbox directories so bind mounts don't fail (but don't copy config)
     cj::sandbox::create_dirs "$sandbox_home"
@@ -234,6 +285,7 @@ _claude_jail_debug() {
     cj::worktree::detect_config "$project_dir" false
     cj::sandbox::bind_credentials "$sandbox_home" "$profile" || true
     cj::env::passthrough
+    cj::git::detect_worktree "$project_dir" "$(cj::config::get_bool git_worktree_ro false && echo true || echo false)" false "" || true
 
     local chdir_path
     chdir_path="$(cj::sandbox::chdir_path "$project_dir" "$profile")"

--- a/claude-jail.plugin.zsh
+++ b/claude-jail.plugin.zsh
@@ -28,6 +28,12 @@ if (( $+functions[zstyle] )); then
     if [[ -z "$CJ_SANDBOX_HOME" ]]; then
         zstyle -s ':claude-jail:*' sandbox-home _zs_value 2>/dev/null && export CJ_SANDBOX_HOME="$_zs_value"
     fi
+    if [[ -z "$CJ_SANDBOX_NAME" ]]; then
+        zstyle -s ':claude-jail:*' sandbox-name _zs_value 2>/dev/null && export CJ_SANDBOX_NAME="$_zs_value"
+    fi
+    if [[ -z "$CJ_GIT_WORKTREE_RO" ]]; then
+        zstyle -b ':claude-jail:*' git-worktree-ro _zs_value 2>/dev/null && export CJ_GIT_WORKTREE_RO="$([[ $_zs_value == yes ]] && echo true || echo false)"
+    fi
     if [[ -z "$CJ_COPY_CLAUDE_CONFIG" ]]; then
         zstyle -b ':claude-jail:*' copy-claude-config _zs_value 2>/dev/null && export CJ_COPY_CLAUDE_CONFIG="$([[ $_zs_value == yes ]] && echo true || echo false)"
     fi
@@ -128,6 +134,10 @@ if [[ -n "$ZSH_VERSION" ]]; then
             '--no-network[Disable network]' \
             '*--ro[Read-only path]:path:_files -/' \
             '*--rw[Read-write path]:path:_files -/' \
+            '--sandbox-home[Parent directory for sandbox]:directory:_files -/' \
+            '--sandbox-name[Sandbox directory name]:name:' \
+            '--git-root[Main git repo root for worktrees]:directory:_files -/' \
+            '--git-ro[Bind main .git read-only]' \
             '--list-profiles[List profiles]' \
             '--show-config[Show configuration]' \
             '--help-config[Show configuration help]' \

--- a/tests/unit/git_worktree.bats
+++ b/tests/unit/git_worktree.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats
+# tests/unit/git_worktree.bats - Unit tests for git worktree detection
+
+load '../test_helper/common'
+
+setup() {
+    setup_test_tmpdir
+    source_bwrap
+}
+
+teardown() {
+    teardown_test_tmpdir
+}
+
+# =============================================================================
+# Helper functions for creating test git structures
+# =============================================================================
+
+# Create a mock primary git clone (with .git directory)
+create_mock_primary_clone() {
+    local dir="$1"
+    mkdir -p "$dir/.git/objects" "$dir/.git/refs"
+    echo "ref: refs/heads/main" > "$dir/.git/HEAD"
+}
+
+# Create a mock worktree (with .git file pointing to main repo)
+# Usage: create_mock_worktree <worktree_dir> <main_repo_dir>
+create_mock_worktree() {
+    local worktree_dir="$1"
+    local main_repo_dir="$2"
+    local worktree_name
+    worktree_name="$(basename "$worktree_dir")"
+
+    mkdir -p "$worktree_dir"
+    mkdir -p "$main_repo_dir/.git/worktrees/$worktree_name"
+
+    # Create the gitdir file in worktree
+    echo "gitdir: $main_repo_dir/.git/worktrees/$worktree_name" > "$worktree_dir/.git"
+
+    # Create the commondir file in the worktree-specific git dir
+    # Points from worktrees/<name> up to .git (two levels up)
+    echo "../.." > "$main_repo_dir/.git/worktrees/$worktree_name/commondir"
+}
+
+# =============================================================================
+# cj::git::get_main_repo_root tests
+# =============================================================================
+
+@test "cj::git::get_main_repo_root returns project dir for primary clone" {
+    local project="$TEST_TMPDIR/primary"
+    create_mock_primary_clone "$project"
+
+    run cj::git::get_main_repo_root "$project"
+    assert_success
+    assert_output "$project"
+}
+
+@test "cj::git::get_main_repo_root returns main repo for worktree" {
+    local main="$TEST_TMPDIR/main"
+    local worktree="$TEST_TMPDIR/feat-branch"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    run cj::git::get_main_repo_root "$worktree"
+    assert_success
+    assert_output "$main"
+}
+
+@test "cj::git::get_main_repo_root fails for non-git directory" {
+    local dir="$TEST_TMPDIR/not-git"
+    mkdir -p "$dir"
+
+    run cj::git::get_main_repo_root "$dir"
+    assert_failure
+}
+
+@test "cj::git::get_main_repo_root fails for empty argument" {
+    run cj::git::get_main_repo_root ""
+    assert_failure
+}
+
+@test "cj::git::get_main_repo_root handles sibling worktree layout" {
+    # Layout:
+    # parent/
+    #   main/        <- primary clone
+    #   feat-branch/ <- worktree
+    local parent="$TEST_TMPDIR/parent"
+    local main="$parent/main"
+    local worktree="$parent/feat-branch"
+
+    mkdir -p "$parent"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    run cj::git::get_main_repo_root "$worktree"
+    assert_success
+    assert_output "$main"
+}
+
+# =============================================================================
+# cj::git::detect_worktree tests
+# =============================================================================
+
+@test "cj::git::detect_worktree succeeds for primary clone (no extra binding)" {
+    local project="$TEST_TMPDIR/primary"
+    create_mock_primary_clone "$project"
+
+    # Call directly (not with run) so _CJ_BINDS is modified
+    cj::git::detect_worktree "$project" false false ""
+    local result=$?
+
+    # Should succeed
+    assert_equal "$result" 0
+
+    # Should not have bound anything extra (primary .git is part of project)
+    local found=false
+    for item in "${_CJ_BINDS[@]}"; do
+        [[ "$item" == "$project/.git" ]] && found=true
+    done
+    assert [ "$found" = false ]
+}
+
+@test "cj::git::detect_worktree binds main .git for worktree" {
+    local main="$TEST_TMPDIR/main"
+    local worktree="$TEST_TMPDIR/feat-branch"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    # Call directly so _CJ_BINDS is modified
+    cj::git::detect_worktree "$worktree" false false ""
+    local result=$?
+
+    assert_equal "$result" 0
+    # Should have bound main/.git
+    assert_array_contains _CJ_BINDS "$main/.git"
+}
+
+@test "cj::git::detect_worktree binds read-write by default" {
+    local main="$TEST_TMPDIR/main"
+    local worktree="$TEST_TMPDIR/feat-branch"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    cj::git::detect_worktree "$worktree" false false ""
+
+    # Should use --bind (read-write), not --ro-bind
+    assert_array_contains _CJ_BINDS "--bind"
+}
+
+@test "cj::git::detect_worktree binds read-only when requested" {
+    local main="$TEST_TMPDIR/main"
+    local worktree="$TEST_TMPDIR/feat-branch"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    cj::git::detect_worktree "$worktree" true false ""
+
+    # Should use --ro-bind (read-only)
+    assert_array_contains _CJ_BINDS "--ro-bind"
+}
+
+@test "cj::git::detect_worktree fails for non-git directory" {
+    local dir="$TEST_TMPDIR/not-git"
+    mkdir -p "$dir"
+
+    run cj::git::detect_worktree "$dir" false false ""
+    assert_failure
+}
+
+@test "cj::git::detect_worktree uses manual git root override" {
+    local main="$TEST_TMPDIR/main"
+    local project="$TEST_TMPDIR/project"
+    create_mock_primary_clone "$main"
+    mkdir -p "$project"  # Not a git repo, but we'll override
+
+    # Create a .git file to make it look like a worktree (but broken)
+    echo "gitdir: /nonexistent/path" > "$project/.git"
+
+    # Use manual override - call directly so _CJ_BINDS is modified
+    cj::git::detect_worktree "$project" false false "$main"
+
+    # Should have bound the manually specified main/.git
+    assert_array_contains _CJ_BINDS "$main/.git"
+}
+
+@test "cj::git::detect_worktree fails with invalid manual git root" {
+    local project="$TEST_TMPDIR/project"
+    mkdir -p "$project"
+    touch "$project/.git"  # Make it look like a worktree
+
+    run cj::git::detect_worktree "$project" false false "$TEST_TMPDIR/nonexistent"
+    assert_failure
+    assert_output --partial "does not contain .git"
+}
+
+@test "cj::git::detect_worktree skips binding if main .git inside project" {
+    # Edge case: main .git is somehow inside project directory
+    local project="$TEST_TMPDIR/project"
+    mkdir -p "$project/subrepo"
+    create_mock_primary_clone "$project/subrepo"
+
+    # Create a worktree that points to subrepo - need ../.. to point to .git
+    echo "gitdir: $project/subrepo/.git/worktrees/fake" > "$project/.git"
+    mkdir -p "$project/subrepo/.git/worktrees/fake"
+    echo "../.." > "$project/subrepo/.git/worktrees/fake/commondir"
+
+    # The main .git is inside project, so no extra binding needed
+    cj::git::detect_worktree "$project" false false ""
+
+    # Should succeed and not bind (since it's already inside project)
+    local found=false
+    for item in "${_CJ_BINDS[@]}"; do
+        [[ "$item" == "$project/subrepo/.git" ]] && found=true
+    done
+    # In this case it shouldn't matter either way, just shouldn't fail
+}
+
+# =============================================================================
+# Verbose output tests
+# =============================================================================
+
+@test "cj::git::detect_worktree prints verbose output when enabled" {
+    local main="$TEST_TMPDIR/main"
+    local worktree="$TEST_TMPDIR/feat-branch"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    run cj::git::detect_worktree "$worktree" false true ""
+    assert_success
+    assert_output --partial "Git:"
+}
+
+@test "cj::git::detect_worktree silent when verbose disabled" {
+    local main="$TEST_TMPDIR/main"
+    local worktree="$TEST_TMPDIR/feat-branch"
+    create_mock_primary_clone "$main"
+    create_mock_worktree "$worktree" "$main"
+
+    run cj::git::detect_worktree "$worktree" false false ""
+    assert_success
+    assert_output ""
+}

--- a/tests/unit/sandbox_home.bats
+++ b/tests/unit/sandbox_home.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+# tests/unit/sandbox_home.bats - Unit tests for sandbox home resolution
+
+load '../test_helper/common'
+
+setup() {
+    setup_test_tmpdir
+    # Clear environment variables before each test
+    unset CJ_PROFILE CJ_NETWORK CJ_SANDBOX_HOME CJ_SANDBOX_NAME
+    unset CJ_COPY_CLAUDE_CONFIG CJ_VERBOSE CJ_GIT_WORKTREE_RO
+    unset CJ_EXTRA_RO CJ_EXTRA_RW CJ_BLOCKED CJ_CONFIG_FILE
+    source_sandbox
+    # Reset config to defaults
+    _CJ_CONFIG[sandbox_home]=".claude-sandbox"
+    _CJ_CONFIG[sandbox_name]=".claude-sandbox"
+}
+
+teardown() {
+    teardown_test_tmpdir
+}
+
+# =============================================================================
+# cj::sandbox::resolve_home tests
+# =============================================================================
+
+@test "cj::sandbox::resolve_home uses cwd by default" {
+    cd "$TEST_TMPDIR"
+
+    run cj::sandbox::resolve_home
+    assert_success
+    assert_output "$TEST_TMPDIR/.claude-sandbox"
+}
+
+@test "cj::sandbox::resolve_home respects parent override" {
+    local parent="$TEST_TMPDIR/custom-parent"
+    mkdir -p "$parent"
+
+    run cj::sandbox::resolve_home "$parent"
+    assert_success
+    assert_output "$parent/.claude-sandbox"
+}
+
+@test "cj::sandbox::resolve_home respects name override" {
+    cd "$TEST_TMPDIR"
+
+    run cj::sandbox::resolve_home "" ".my-sandbox"
+    assert_success
+    assert_output "$TEST_TMPDIR/.my-sandbox"
+}
+
+@test "cj::sandbox::resolve_home respects both overrides" {
+    local parent="$TEST_TMPDIR/parent"
+    mkdir -p "$parent"
+
+    run cj::sandbox::resolve_home "$parent" ".custom-name"
+    assert_success
+    assert_output "$parent/.custom-name"
+}
+
+@test "cj::sandbox::resolve_home uses config sandbox_name when sandbox_home is absolute" {
+    cd "$TEST_TMPDIR"
+    # Set sandbox_home to absolute path (new behavior)
+    _CJ_CONFIG[sandbox_home]="$TEST_TMPDIR"
+    _CJ_CONFIG[sandbox_name]=".config-sandbox"
+
+    run cj::sandbox::resolve_home
+    assert_success
+    assert_output "$TEST_TMPDIR/.config-sandbox"
+}
+
+@test "cj::sandbox::resolve_home treats relative sandbox_home as name (backward compat)" {
+    cd "$TEST_TMPDIR"
+    # Old behavior: sandbox_home was the directory name, not parent
+    _CJ_CONFIG[sandbox_home]=".old-style-sandbox"
+    _CJ_CONFIG[sandbox_name]=".new-style-sandbox"
+
+    run cj::sandbox::resolve_home
+    assert_success
+    # Should use the old sandbox_home value as the name (backward compatibility)
+    assert_output "$TEST_TMPDIR/.old-style-sandbox"
+}
+
+@test "cj::sandbox::resolve_home uses absolute sandbox_home as parent" {
+    local custom_parent="$TEST_TMPDIR/custom-parent"
+    mkdir -p "$custom_parent"
+    _CJ_CONFIG[sandbox_home]="$custom_parent"
+    _CJ_CONFIG[sandbox_name]=".my-sandbox"
+
+    run cj::sandbox::resolve_home
+    assert_success
+    assert_output "$custom_parent/.my-sandbox"
+}
+
+# =============================================================================
+# cj::sandbox::validate_home_location tests
+# =============================================================================
+
+@test "cj::sandbox::validate_home_location accepts valid path" {
+    run cj::sandbox::validate_home_location "$TEST_TMPDIR/.claude-sandbox"
+    assert_success
+}
+
+@test "cj::sandbox::validate_home_location rejects root" {
+    run cj::sandbox::validate_home_location "/"
+    assert_failure
+    assert_output --partial "system directory"
+}
+
+@test "cj::sandbox::validate_home_location rejects /etc" {
+    run cj::sandbox::validate_home_location "/etc"
+    assert_failure
+    assert_output --partial "system directory"
+}
+
+@test "cj::sandbox::validate_home_location rejects /home" {
+    run cj::sandbox::validate_home_location "/home"
+    assert_failure
+    assert_output --partial "system directory"
+}
+
+@test "cj::sandbox::validate_home_location rejects /usr" {
+    run cj::sandbox::validate_home_location "/usr"
+    assert_failure
+    assert_output --partial "system directory"
+}
+
+@test "cj::sandbox::validate_home_location rejects /tmp" {
+    run cj::sandbox::validate_home_location "/tmp"
+    assert_failure
+    assert_output --partial "system directory"
+}
+
+@test "cj::sandbox::validate_home_location rejects /var" {
+    run cj::sandbox::validate_home_location "/var"
+    assert_failure
+    assert_output --partial "system directory"
+}
+
+@test "cj::sandbox::validate_home_location rejects empty path" {
+    run cj::sandbox::validate_home_location ""
+    assert_failure
+    assert_output --partial "cannot be empty"
+}
+
+@test "cj::sandbox::validate_home_location accepts subdirectory of /tmp" {
+    run cj::sandbox::validate_home_location "/tmp/my-sandbox"
+    assert_success
+}
+
+@test "cj::sandbox::validate_home_location accepts subdirectory of /home" {
+    run cj::sandbox::validate_home_location "/home/user/project/.sandbox"
+    assert_success
+}
+
+@test "cj::sandbox::validate_home_location warns for user-level config" {
+    run cj::sandbox::validate_home_location "$TEST_TMPDIR/.sandbox" "user"
+    assert_success
+    assert_output --partial "Warning"
+    assert_output --partial "user-level config"
+}
+
+@test "cj::sandbox::validate_home_location no warning for project config" {
+    run cj::sandbox::validate_home_location "$TEST_TMPDIR/.sandbox" "project"
+    assert_success
+    refute_output --partial "Warning"
+}
+
+@test "cj::sandbox::validate_home_location no warning without source" {
+    run cj::sandbox::validate_home_location "$TEST_TMPDIR/.sandbox"
+    assert_success
+    refute_output --partial "Warning"
+}
+
+# =============================================================================
+# Integration with config tests
+# =============================================================================
+
+@test "sandbox resolution works with CJ_SANDBOX_HOME env var" {
+    local custom_parent="$TEST_TMPDIR/env-parent"
+    mkdir -p "$custom_parent"
+    export CJ_SANDBOX_HOME="$custom_parent"
+    cj::config::init
+
+    run cj::sandbox::resolve_home
+    assert_success
+    assert_output "$custom_parent/.claude-sandbox"
+}
+
+@test "sandbox resolution works with CJ_SANDBOX_NAME env var" {
+    cd "$TEST_TMPDIR"
+    # Need to set sandbox_home to absolute path for sandbox_name to take effect
+    export CJ_SANDBOX_HOME="$TEST_TMPDIR"
+    export CJ_SANDBOX_NAME=".env-sandbox"
+    cj::config::init
+
+    run cj::sandbox::resolve_home
+    assert_success
+    assert_output "$TEST_TMPDIR/.env-sandbox"
+}
+
+@test "sandbox resolution works with both env vars" {
+    local custom_parent="$TEST_TMPDIR/env-parent"
+    mkdir -p "$custom_parent"
+    export CJ_SANDBOX_HOME="$custom_parent"
+    export CJ_SANDBOX_NAME=".env-sandbox"
+    cj::config::init
+
+    run cj::sandbox::resolve_home
+    assert_success
+    assert_output "$custom_parent/.env-sandbox"
+}
+
+# =============================================================================
+# cj::config::is_user_level_config tests
+# =============================================================================
+
+@test "cj::config::is_user_level_config returns false when no config loaded" {
+    _CJ_CONFIG_SOURCE=""
+
+    if cj::config::is_user_level_config; then
+        fail "Expected non-user-level config"
+    fi
+}
+
+@test "cj::config::is_user_level_config returns true for user config path" {
+    _CJ_CONFIG_SOURCE="${XDG_CONFIG_HOME:-$HOME/.config}/claude-jail/config"
+
+    if cj::config::is_user_level_config; then
+        true  # Expected
+    else
+        fail "Expected user-level config detection"
+    fi
+}
+
+@test "cj::config::is_user_level_config returns true for home config path" {
+    _CJ_CONFIG_SOURCE="$HOME/.claude-jail.conf"
+
+    if cj::config::is_user_level_config; then
+        true  # Expected
+    else
+        fail "Expected user-level config detection"
+    fi
+}
+
+@test "cj::config::is_user_level_config returns false for project config" {
+    _CJ_CONFIG_SOURCE="./.claude-jail.conf"
+
+    if cj::config::is_user_level_config; then
+        fail "Expected non-user-level config for project config"
+    fi
+}


### PR DESCRIPTION
Add automatic detection and binding of main .git directory for git worktrees, enabling full git operations from worktree directories.

Changes:
- Add cj::git::detect_worktree() and cj::git::get_main_repo_root() to auto-detect worktrees and bind main .git directory
- Add cj::sandbox::resolve_home() for flexible sandbox location (default: cwd instead of project_dir)
- Add cj::sandbox::validate_home_location() to reject system dirs
- Add CLI options: --sandbox-home, --sandbox-name, --git-root, --git-ro
- Add config options: CJ_SANDBOX_NAME, CJ_GIT_WORKTREE_RO
- Update zsh plugin with new completions and zstyle support
- Add unit tests for git worktree detection (15 tests)
- Add unit tests for sandbox home resolution (27 tests)

This allows running claude-jail from a parent directory containing multiple worktrees with a shared sandbox:

  cd bean-barn
  claude-jail -d feat-branch  # Auto-binds main/.git
  claude-jail -d main         # Same sandbox (shared)