### PR TITLE
feat(clod): add init subcommand for interactive config setup

### DIFF
--- a/clod-py/CLAUDE.md
+++ b/clod-py/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 
 ```
 src/clod/
-  cli.py           # Click-based CLI - 'clod jail' command
+  cli.py           # Click-based CLI - 'clod init' and 'clod jail' commands
   bwrap.py         # BwrapBuilder class - constructs bwrap argument lists
   sandbox.py       # Sandbox initialization and dev profile logic
   config/
@@ -62,6 +62,11 @@ clod.plugin.zsh    # Zsh plugin (completions + 'cj' alias)
 ```bash
 # Install dependencies
 uv sync
+
+# Initialize user config (interactive)
+uv run clod init
+uv run clod init -y        # Accept all defaults
+uv run clod init --force   # Overwrite existing config
 
 # Run the CLI
 uv run clod jail
@@ -123,6 +128,12 @@ All settings can be overridden via environment variables with `CLOD_` prefix:
 ### CLI Options
 
 ```bash
+# Initialize user config (creates ~/.config/clod/config.toml)
+clod init              # Interactive - prompts for each setting
+clod init -y           # Accept all defaults without prompting
+clod init --force      # Overwrite existing config file
+clod init --force -y   # Overwrite with defaults, no prompts
+
 # Use specific config file (skips all discovery)
 clod -c myconfig.toml jail
 

--- a/clod-py/src/clod/cli.py
+++ b/clod-py/src/clod/cli.py
@@ -13,6 +13,8 @@ import click
 from clod.config import (
     ClodSettings,
     ConfigError,
+    discover_user_config,
+    get_config_home,
     get_sandbox_home,
     set_config_context,
 )
@@ -41,6 +43,10 @@ def cli(ctx: click.Context, config_file: Path | None, project_dir: Path | None) 
     """clod - Minimal bubblewrap sandbox for Claude Code."""
     # Ensure ctx.obj exists
     ctx.ensure_object(dict)
+
+    # Skip settings loading for init command (doesn't need existing config)
+    if ctx.invoked_subcommand == "init":
+        return
 
     # Resolve project directory
     if project_dir is None:
@@ -162,6 +168,131 @@ def jail(
     except Exception as e:
         click.echo(f"Error running sandbox: {e}", err=True)
         sys.exit(1)
+
+
+@cli.command()
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Accept all defaults without prompting",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite existing config file",
+)
+@click.pass_context
+def init(ctx: click.Context, yes: bool, force: bool) -> None:
+    """Initialize user configuration.
+
+    Creates the user config directory and populates it with a default
+    config.toml file. By default, interactively prompts for each setting.
+
+    Examples:
+
+        \b
+        # Interactive setup
+        clod init
+
+        \b
+        # Accept all defaults
+        clod init -y
+
+        \b
+        # Overwrite existing config
+        clod init --force
+    """
+    config_home = get_config_home()
+    config_file = config_home / "config.toml"
+
+    # Check if config already exists
+    existing_config = discover_user_config()
+    if existing_config and not force:
+        click.echo(f"Config file already exists: {existing_config}")
+        if not click.confirm("Overwrite?", default=False):
+            click.echo("Aborted.")
+            sys.exit(0)
+
+    # Create config directory
+    config_home.mkdir(parents=True, exist_ok=True)
+
+    # Get default values from ClodSettings field defaults
+    defaults = {
+        "sandbox_name": ClodSettings.model_fields["sandbox_name"].default,
+        "enable_network": ClodSettings.model_fields["enable_network"].default,
+        "term": ClodSettings.model_fields["term"].default,
+        "lang": ClodSettings.model_fields["lang"].default,
+        "shell": ClodSettings.model_fields["shell"].default,
+    }
+
+    if yes:
+        # Use all defaults
+        values = defaults
+        click.echo("Using default configuration...")
+    else:
+        # Interactive prompts
+        click.echo("Configure clod settings (press Enter to accept defaults):\n")
+
+        values = {}
+
+        # sandbox_name
+        values["sandbox_name"] = click.prompt(
+            "Sandbox directory name",
+            default=defaults["sandbox_name"],
+            type=str,
+        )
+
+        # enable_network
+        values["enable_network"] = click.confirm(
+            "Enable network access",
+            default=defaults["enable_network"],
+        )
+
+        # term
+        values["term"] = click.prompt(
+            "TERM environment variable",
+            default=defaults["term"],
+            type=str,
+        )
+
+        # lang
+        values["lang"] = click.prompt(
+            "LANG environment variable",
+            default=defaults["lang"],
+            type=str,
+        )
+
+        # shell
+        values["shell"] = click.prompt(
+            "SHELL environment variable",
+            default=defaults["shell"],
+            type=str,
+        )
+
+        click.echo()
+
+    # Generate TOML content
+    toml_lines = [
+        "# clod user configuration",
+        "# See: https://github.com/mbarlow12/claude-jail/tree/main/clod-py",
+        "",
+        f'sandbox_name = "{values["sandbox_name"]}"',
+        f'enable_network = {str(values["enable_network"]).lower()}',
+        f'term = "{values["term"]}"',
+        f'lang = "{values["lang"]}"',
+        f'shell = "{values["shell"]}"',
+        "",
+    ]
+    toml_content = "\n".join(toml_lines)
+
+    # Write config file
+    config_file.write_text(toml_content)
+
+    click.echo(f"Created config file: {config_file}")
+    click.echo("\nConfiguration:")
+    for key, value in values.items():
+        click.echo(f"  {key}: {value}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds `clod init` command that creates the user config directory
(~/.config/clod) and populates it with a config.toml file. Features:
- Interactive prompts for each setting with defaults
- `-y/--yes` flag to accept all defaults without prompting
- `--force` flag to overwrite existing config

https://claude.ai/code/session_013Nt6npXXD3hZueKBvb5eov